### PR TITLE
fixing block width and padding

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,6 +1,4 @@
 .accordion {
-  background: black;
-
   --accordion-pseudo-title-bg-image: ''; /* updated via js */
 }
 

--- a/blocks/cards-grid/cards-grid.css
+++ b/blocks/cards-grid/cards-grid.css
@@ -1,7 +1,7 @@
 .cards-grid {
   position: relative;
   display: grid;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: auto auto;
   align-items: start;
 
   --card-background-color: var(--navy-blue);
@@ -26,7 +26,7 @@
 
 @media (width > 767px) {
   .cards-grid {
-    grid-template-rows: 2fr 1fr;
+    grid-template-rows: auto auto;
     gap: 1rem;
   }
 
@@ -53,7 +53,7 @@
 
 @media (width > 990px) {
   .cards-grid {
-    grid-template-rows: 2fr 1fr;
+    grid-template-rows: auto auto;
   }
 
   .cards-grid > .row {

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -1,5 +1,5 @@
 .footer .section.footer-links .default-content-wrapper {
-  padding: 5rem 2rem;
+  padding-block: 5rem;
 }
 
 .footer .footer-links {

--- a/blocks/hero-slider/hero-slider.css
+++ b/blocks/hero-slider/hero-slider.css
@@ -27,7 +27,7 @@ div.section.hero-slider-container {
 
 @media (width > 990px) {
   div.section.hero-slider-container {
-    margin-bottom: 7.5rem;
+    margin-bottom: 10rem;
   }
 
   .hero-slider {

--- a/blocks/hero-slider/hero-slider.js
+++ b/blocks/hero-slider/hero-slider.js
@@ -78,8 +78,12 @@ function stopAllActiveItems(block) {
     currentProgressBar.setAttribute('state', 'ended');
   }
 
-  const currentBanner = block.querySelector('.banner.active');
-  if (currentBanner) currentBanner.classList.remove('active');
+  const currentActiveBanners = block.querySelectorAll('.banner.active');
+  if (currentActiveBanners && currentActiveBanners.length > 0) {
+    currentActiveBanners.forEach((banner) => {
+      banner.classList.remove('active');
+    });
+  }
 
   const currentCardItem = block.querySelector('.card-item.active');
   if (currentCardItem) {

--- a/blocks/hero-slider/hero-slider.js
+++ b/blocks/hero-slider/hero-slider.js
@@ -38,11 +38,42 @@ function setBannerImage(banner, block) {
   });
 }
 
+function stopAllActiveItems(block) {
+  const currentProgressBar = block.querySelector('.progress-bar[state="started"]');
+  if (currentProgressBar) {
+    currentProgressBar.style.width = '0px';
+    currentProgressBar.setAttribute('state', 'ended');
+  }
+
+  const currentActiveBanners = block.querySelectorAll('.banner.active');
+  if (currentActiveBanners && currentActiveBanners.length > 0) {
+    currentActiveBanners.forEach((banner) => {
+      banner.classList.remove('active');
+    });
+  }
+
+  const currentCardItem = block.querySelector('.card-item.active');
+  if (currentCardItem) {
+    currentCardItem.classList.remove('active');
+    currentCardItem.classList.remove('animate-l2r');
+    currentCardItem.classList.remove('animate-r2l');
+  }
+
+  const tile = block.querySelector('li.tile.active');
+  if (tile) tile.classList.remove('active');
+
+  clearTimeout(block.timeoutId);
+}
+
 function setActiveItemsByIndex(block, prevIndex, newIndex) {
   const cardsList = block.querySelector('.cards-list');
   const newBanner = block.querySelector(`.banner-${newIndex}`);
   const newCardItem = block.querySelector(`.card-${newIndex}`);
   const newTile = block.querySelector(`.tile-${newIndex}`);
+  // make sure all active items are stopped before setting new active items
+  stopAllActiveItems(block);
+
+  // update active items
   newBanner.classList.add('active');
   newCardItem.classList.add('active');
   newTile.classList.add('active');
@@ -71,33 +102,6 @@ const setCardsListVisibleItems = (block) => {
   setActiveItemsByIndex(block, 0, 0);
 };
 
-function stopAllActiveItems(block) {
-  const currentProgressBar = block.querySelector('.progress-bar[state="started"]');
-  if (currentProgressBar) {
-    currentProgressBar.style.width = '0px';
-    currentProgressBar.setAttribute('state', 'ended');
-  }
-
-  const currentActiveBanners = block.querySelectorAll('.banner.active');
-  if (currentActiveBanners && currentActiveBanners.length > 0) {
-    currentActiveBanners.forEach((banner) => {
-      banner.classList.remove('active');
-    });
-  }
-
-  const currentCardItem = block.querySelector('.card-item.active');
-  if (currentCardItem) {
-    currentCardItem.classList.remove('active');
-    currentCardItem.classList.remove('animate-l2r');
-    currentCardItem.classList.remove('animate-r2l');
-  }
-
-  const tile = block.querySelector('li.tile.active');
-  if (tile) tile.classList.remove('active');
-
-  clearTimeout(block.timeoutId);
-}
-
 function startProgressBar(block, currentIndex) {
   const progressBars = block.querySelectorAll('.progress-bar');
   const cardItemWidth = parseFloat(progressBars[currentIndex].style.maxWidth || 0);
@@ -112,7 +116,6 @@ function startProgressBar(block, currentIndex) {
 
     // current progress bar reached 100% width
     if (width >= cardItemWidth) {
-      stopAllActiveItems(block);
       // If last progress bar, scroll the cards list back to the first card
       newIndex = (currentIndex + 1) % progressBars.length;
       setActiveItemsByIndex(block, currentIndex, newIndex);
@@ -129,7 +132,6 @@ function moveNextCard(block) {
   const currentCardItem = block.querySelector('.card-item.active');
   const currentIndex = [...cardItems].indexOf(currentCardItem);
   const nextIndex = (currentIndex + 1) % cardItems.length;
-  stopAllActiveItems(block);
   setActiveItemsByIndex(block, currentIndex, nextIndex);
   startProgressBar(block, nextIndex);
 }
@@ -139,7 +141,6 @@ function movePrevCard(block) {
   const currentCardItem = block.querySelector('.card-item.active');
   const currentIndex = [...cardItems].indexOf(currentCardItem);
   const prevIndex = (currentIndex - 1 + cardItems.length) % cardItems.length;
-  stopAllActiveItems(block);
   setActiveItemsByIndex(block, currentIndex, prevIndex);
   startProgressBar(block, prevIndex);
 }
@@ -196,8 +197,6 @@ function decorateTilesControls(block) {
     const tile = createAemElement('li', { class: `tile tile-${i}` });
     tile.addEventListener('click', () => {
       const currentIndex = getCurrentIndex(block);
-      stopAllActiveItems(block);
-      tile.classList.add('active');
       setActiveItemsByIndex(block, currentIndex, i);
       startProgressBar(block, i);
     });
@@ -225,7 +224,6 @@ function decorateHeroSlidingCards(block) {
     cardsList.appendChild(card);
     card.addEventListener('click', () => {
       const currentIndex = getCurrentIndex(block);
-      stopAllActiveItems(block);
       setActiveItemsByIndex(block, currentIndex, index);
       startProgressBar(block, index);
     });
@@ -253,8 +251,11 @@ const setProgressBarPosition = (block) => {
 
 function onLoadSetItemsPosition(block) {
   document.addEventListener('load', () => {
+    const onLoadEventHandled = block.getAttribute('data-onload-event');
+    if (onLoadEventHandled === 'true') return;
     setCardsListVisibleItems(block);
     setProgressBarPosition(block);
+    block.setAttribute('data-onload-event', 'true');
   }, true);
 
   window.addEventListener('resize', () => {

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -11,6 +11,9 @@
  */
 
 /* eslint-env browser */
+const BREAKPOINTS = {
+  large: window.matchMedia('(min-width: 1210px)'),
+};
 
 /**
  * log RUM if part of the sample.
@@ -518,8 +521,8 @@ function decorateSections(main) {
     if (sectionMeta) {
       const meta = readBlockConfig(sectionMeta);
       Object.keys(meta).forEach((key) => {
-        if (key === 'style') {
-          const styles = meta.style
+        if (key === 'style' || (key === 'style-large' && BREAKPOINTS.large.matches)) {
+          const styles = meta[key]
             .split(',')
             .filter((style) => style)
             .map((style) => toClassName(style.trim()));

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -274,16 +274,17 @@ main .section.small-header h1 {
   padding: 1.6rem 0;
 }
 
+/* sections */
 main .section.black-background {
   margin: 0;
   background-color: black;
 }
 
-main .section.no-margin, main .section.no-margin h1 {
+main .section.no-margin,
+main .section.no-margin h1 {
   margin: 0;
 }
 
-/* sections */
 main .section:not(.no-padding) {
   padding-top: 64px;
 }
@@ -294,22 +295,26 @@ main .section > div > div {
   margin: auto;
 }
 
-.section > .default-content-wrapper,
+main .section > div > h1,
+main .section > div > h2,
+footer .default-content-wrapper,
 main .section > div > div:not(.full-width) {
   max-width: calc(100% - 40px);
   margin: auto;
 }
 
 main .section > div > h2 {
-  margin: 0;
+  margin-block: 0;
   padding-bottom: 2rem;
 }
 
 @media (width > 1210px) {
-  .section > .default-content-wrapper,
+  main .section > div > h1,
+  main .section > div > h2,
+  footer .default-content-wrapper,
   main .section > div > div:not(.full-width) {
     max-width: 1170px;
-    margin: auto;
+    margin-inline: auto;
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -285,25 +285,30 @@ main .section.no-margin, main .section.no-margin h1 {
 
 /* sections */
 main .section:not(.no-padding) {
-  padding-block: 64px;
+  padding-top: 64px;
 }
 
-main .section:not(.no-inline-padding) {
-  padding-inline: 20px;
-}
-
-main .section > div > div.full-width, main .section > div:has(div.full-width) {
+main .section > div,
+main .section > div > div {
   max-width: 100%;
+  margin: auto;
 }
 
-@media (width > 900px) {
-  .section > div:not(>div.full-width), .section > div > div:not(.full-width) {
-    max-width: 1210px;
-    margin: auto;
-  }
+.section > .default-content-wrapper,
+main .section > div > div:not(.full-width) {
+  max-width: calc(100% - 40px);
+  margin: auto;
+}
 
-  .section > div:has(div.full-width-background) {
-    max-width: 100%;
+main .section > div > h2 {
+  margin: 0;
+  padding-bottom: 2rem;
+}
+
+@media (width > 1210px) {
+  .section > .default-content-wrapper,
+  main .section > div > div:not(.full-width) {
+    max-width: 1170px;
     margin: auto;
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -274,47 +274,39 @@ main .section.small-header h1 {
   padding: 1.6rem 0;
 }
 
-/* sections */
 main .section.black-background {
   margin: 0;
   background-color: black;
 }
 
 main .section.no-margin,
-main .section.no-margin h1 {
+main .section.no-margin h1:first-of-type,
+main .section.no-margin h2:first-of-type {
   margin: 0;
 }
 
-main .section:not(.no-padding) {
+/* sections */
+main .section:not(.no-top-padding) {
   padding-top: 64px;
 }
 
-main .section > div,
-main .section > div > div {
+main .section:not(.no-inline-padding) > div:not(:has(.full-width)) {
+  padding-inline: 20px;
+}
+
+main .section > div > div.full-width, main .section > div:has(div.full-width) {
   max-width: 100%;
-  margin: auto;
-}
-
-main .section > div > h1,
-main .section > div > h2,
-footer .default-content-wrapper,
-main .section > div > div:not(.full-width) {
-  max-width: calc(100% - 40px);
-  margin: auto;
-}
-
-main .section > div > h2 {
-  margin-block: 0;
-  padding-bottom: 2rem;
 }
 
 @media (width > 1210px) {
-  main .section > div > h1,
-  main .section > div > h2,
-  footer .default-content-wrapper,
-  main .section > div > div:not(.full-width) {
+  .section > div, .section > div > div {
     max-width: 1170px;
-    margin-inline: auto;
+    margin: auto;
+  }
+
+  .section > div:has(div.full-width-background) {
+    max-width: 100%;
+    margin: auto;
   }
 }
 


### PR DESCRIPTION
- Block can occupy full width by using **"Full width"** variant of the block
- Block wrapper takes full width using **"Full Width Background"** variant of the block as required in hero-slider block.
- Section Styling: **"no margin", "no top padding", "no inline padding", "top heading gray", "small header", "black background**
- For defining a separate style for large screens, add a key **"style-large"** in section metadata with required value
- cards-grid block was occupying default more height than the content due to which spacing b/w sections was not coming properly. Fixed this issue.

**hero-slider block**
<img width="646" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/3c4deb67-2aa6-4637-8641-a63da83bbf1d">

**Featured/cards-grid block**
<img width="664" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/0ab209cd-4ca3-4711-9e12-aec45fd50118">

**Our radar / accordion block**
<img width="640" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/c3955d10-0230-49db-830f-ddbd02f00524">

**Subscription block**
<img width="653" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/59a63a6b-a044-4ac0-a50f-0ea769e10e78">


Other changes:
Fixed hero-slider overlapping issue and some refactoring.

Fix #43

Test URLs:
- Before: https://main--infosys--aemsites.hlx.live/drafts/anuj/iki
- After: https://issue-43--infosys--aemsites.hlx.live/drafts/anuj/iki
