### PR TITLE
Explore modal

### DIFF
--- a/blocks/advanced-heading/advanced-heading.css
+++ b/blocks/advanced-heading/advanced-heading.css
@@ -1,0 +1,42 @@
+.advanced-heading.heading-button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.advanced-heading.heading-button a {
+  position: relative;
+  border-radius: 0;
+  border: 1px solid var(--black-olive);
+  background-color: transparent;
+  padding: 1.9rem 0 1.4rem 0;
+  min-width: 17rem;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--black-olive);
+  font-size: 1.4rem;
+  font-weight: 400;
+  z-index: 2;
+}
+
+.advanced-heading.heading-button a:hover {
+  color: white;
+}
+
+.advanced-heading.heading-button a::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 100%;
+  background: linear-gradient(to right, black, black);
+  z-index: 1;
+  transition: width 0.5s ease-in-out;
+  mix-blend-mode: screen;
+}
+
+.advanced-heading.heading-button a:hover::before {
+  width: 100%;
+}
+

--- a/blocks/advanced-heading/advanced-heading.css
+++ b/blocks/advanced-heading/advanced-heading.css
@@ -9,7 +9,7 @@
   border-radius: 0;
   border: 1px solid var(--black-olive);
   background-color: transparent;
-  padding: 1.9rem 0 1.4rem 0;
+  padding: 1.9rem 0 1.4rem;
   min-width: 17rem;
   letter-spacing: 0.8px;
   text-transform: uppercase;

--- a/blocks/advanced-heading/advanced-heading.js
+++ b/blocks/advanced-heading/advanced-heading.js
@@ -1,3 +1,3 @@
 export default function decorate(block) {
-  console.log('Decorating heading custom block', block.outerHTML);
+  console.log('Decorating advanced heading block...');
 }

--- a/blocks/advanced-heading/advanced-heading.js
+++ b/blocks/advanced-heading/advanced-heading.js
@@ -1,3 +1,2 @@
-export default function decorate(block) {
-  console.log('Decorating advanced heading block...');
+export default function decorate() {
 }

--- a/blocks/advanced-heading/advanced-heading.js
+++ b/blocks/advanced-heading/advanced-heading.js
@@ -1,0 +1,3 @@
+export default function decorate(block) {
+  console.log('Decorating heading custom block', block.outerHTML);
+}

--- a/blocks/filters-grid/filters-grid.css
+++ b/blocks/filters-grid/filters-grid.css
@@ -4,8 +4,13 @@ main .modal dialog[data-link="/modals/explore"] {
   margin-top: 25%;
   padding: 1rem 0 0 0;
   border-radius: 0.3rem 0.3rem 0 0;
-  background-color: #00b28f;
+  background-color: var(--spring-green);
   color: white;
+}
+
+main .modal dialog[data-link="/modals/explore"] .modal-content {
+  padding: 0;
+  overflow-y: unset;
 }
 
 @media (width > 767px) {
@@ -87,8 +92,14 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   list-style: none;
   padding: 0;
   gap: 1rem;
-  height: 105px;
+  height: 9rem;
   overflow: hidden;
+}
+
+@media (width > 1600px) {
+  .filters-grid .row ul {
+    height: 10rem;
+  }
 }
 
 @media (width > 767px) {
@@ -116,6 +127,14 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   white-space: nowrap;
   padding: 0.6rem 1.5rem 0.7rem;
   color: var(--bright-blue);
+  font-size: 1.4rem;
+  height: fit-content;
+}
+
+@media (width > 1600px) {
+  .filters-grid .row ul li {
+    font-size: 1.8rem;
+  }
 }
 
 .filters-grid .filters-list li {
@@ -153,7 +172,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   color: white;
   line-height: 1.5;
   font-weight: 900;
-  font-size: 3.6rem;
+  font-size: 2.8rem;
   margin-top: 0;
   margin-bottom: 3rem;
 }
@@ -167,10 +186,16 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   }
 }
 
+@media (width > 1600px) {
+  .filters-grid-container h3 {
+    font-size: 3.6rem;
+  }
+}
+
 .filters-grid h5 {
   padding-bottom: 0.8rem;
   font-family: inherit;
-  font-size: 2rem;
+  font-size: 1.4rem;
   font-weight: 600;
   letter-spacing: initial;
   padding-bottom: 0.6rem;
@@ -190,17 +215,22 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   .filters-grid h5 {
     letter-spacing: 1px;
     text-transform: uppercase;
-    font-size: 1.8rem;
   }
   .filters-grid .row-heading-wrapper::after {
     display: none;
   }
 }
 
+@media (width > 1600px) {
+  .filters-grid h5 {
+    font-size: 1.8rem;
+  }
+}
+
 .filters-grid .view-all {
   text-decoration: none;
   color: black;
-  font-size: 1.4rem;
+  font-size: 1.1rem;
   cursor: pointer;
   display: none;
 }
@@ -208,6 +238,12 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
 @media (width > 767px) {
   .filters-grid .view-all {
     display: block;
+  }
+}
+
+@media (width > 1600px) {
+  .filters-grid .view-all {
+    font-size: 1.4rem;
   }
 }
 
@@ -270,6 +306,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
 .mob-secondary-view .icon.rotate-left {
   transform: rotate(180deg);
   display: inline-block;
+  cursor: pointer;
 }
 
 .mob-secondary-view .icon::before {
@@ -327,7 +364,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
 }
 
 .mob-secondary-view .filters-list li:has(input:not(:checked)) {
-  background-color: #00b28f;
+  background-color: var(--spring-green);
   color: white;
 }
 

--- a/blocks/filters-grid/filters-grid.css
+++ b/blocks/filters-grid/filters-grid.css
@@ -1,36 +1,108 @@
 main .modal dialog[data-link="/modals/explore"] {
   width: 100%;
-  height: 100%;
   max-width: 100%;
-  min-height: fit-content;
-  padding: 2rem;
-  margin-block: 2rem;
-  border-radius: 0;
+  margin-top: 25%;
+  padding: 1rem 0 0 0;
+  border-radius: 0.3rem 0.3rem 0 0;
+  background-color: #00b28f;
+  color: white;
+}
+
+@media (width > 767px) {
+  main .modal dialog[data-link="/modals/explore"] {
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+    min-height: fit-content;
+    padding: 1rem;
+    margin-block: 2rem;
+    background-color: white;
+    color: black;
+  }
 }
 
 @media (width > 1210px) {
   main .modal dialog[data-link="/modals/explore"] {
     max-width: 1170px;
-    padding-inline: 0;
+    padding-inline: 1rem;
     margin-inline: auto;
   }
 }
 
 main .modal dialog[data-link="/modals/explore"] .close-button {
-  margin-top: 5rem;
-  margin-right: 1rem;
-  color: var(--dark-gunmetal);
+  margin-top: 1rem;
+  margin-right: 2rem;
+}
+
+main .modal dialog[data-link="/modals/explore"] .close-button .icon {
+  border: 1px solid white;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
+  font-size: 1.2rem;
+}
+
+@media (width > 767px) {
+  main .modal dialog[data-link="/modals/explore"] .close-button {
+    margin-top: 5rem;
+    margin-right: 3rem;
+  }
+
+  main .modal dialog[data-link="/modals/explore"] .close-button .icon {
+    border: none;
+    color: var(--dark-gunmetal);
+  }
+
+  main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
+    font-size: 1.5rem;
+  }
+}
+
+.filters-grid .row {
+  margin-bottom: 4rem;
+}
+
+.filters-grid .row .row-heading-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.filters-grid .row .row-heading-wrapper .icon {
+  cursor: pointer;
+  font-size: 1.2rem;
 }
 
 .filters-grid .row ul {
   position: relative;
-  display: flex;
+  display: none;
   flex-wrap: wrap;
   list-style: none;
   padding: 0;
   gap: 1rem;
   height: 105px;
   overflow: hidden;
+}
+
+@media (width > 767px) {
+  .filters-grid .row {
+    margin-bottom: 4rem;
+  }
+
+  .filters-grid .row .row-heading-wrapper .icon {
+    display: none;
+  }
+
+  .filters-grid .row ul {
+    display: flex;
+  }
 }
 
 .filters-grid .row ul.expanded {
@@ -75,22 +147,54 @@ main .modal dialog[data-link="/modals/explore"] .close-button {
   color: var(--bright-blue);
 }
 
+/* heading */
 .filters-grid-container h3 {
-  font-family: inherit;
-  color: var(--dark-slate-gray);
+  font-family: tungstenw05-medium, Oswald, sans-serif;
+  color: white;
   line-height: 1.5;
   font-weight: 900;
   font-size: 3.6rem;
-  margin-bottom: 7rem;
+  margin-top: 0;
+  margin-bottom: 3rem;
+}
+
+@media (width > 767px) {
+  .filters-grid-container h3 {
+    font-family: inherit;
+    color: var(--dark-slate-gray);
+    margin-top: 3rem;
+    margin-bottom: 7rem;
+  }
 }
 
 .filters-grid h5 {
-  letter-spacing: 1px;
   padding-bottom: 0.8rem;
-  text-transform: uppercase;
   font-family: inherit;
-  font-size: 1.8rem;
+  font-size: 2rem;
   font-weight: 600;
+  letter-spacing: initial;
+  padding-bottom: 0.6rem;
+  margin: 0;
+}
+
+.filters-grid .separator {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 1px;
+  background: white;
+  margin-bottom: 1.5rem;
+}
+
+@media (width > 767px) {
+  .filters-grid h5 {
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    font-size: 1.8rem;
+  }
+  .filters-grid .row-heading-wrapper::after {
+    display: none;
+  }
 }
 
 .filters-grid .view-all {
@@ -98,29 +202,150 @@ main .modal dialog[data-link="/modals/explore"] .close-button {
   color: black;
   font-size: 1.4rem;
   cursor: pointer;
+  display: none;
+}
+
+@media (width > 767px) {
+  .filters-grid .view-all {
+    display: block;
+  }
 }
 
 .filters-grid-container .action-button-wrapper {
-  margin-top: 3.5rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0;
 }
 
-.filters-grid-container .action-button-wrapper::before {
-  content: '';
-  display: block;
-  width: 100%;
-  height: 1px;
-  background: var(--silver);
+@media (width > 767px) {
+  .filters-grid-container .action-button-wrapper {
+    margin-top: 3.5rem;
+  }
+
+
+  .filters-grid-container .action-button-wrapper::before {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 1px;
+    background: var(--silver);
+  }
 }
 
 .filters-grid-container .action-button-wrapper .action-button {
   border-radius: 0;
   background-color: var(--black-olive);
   color: white;
-  padding: 1.9rem 0 1.4rem 0;
-  min-width: 17rem;
   letter-spacing: 0.8px;
   text-transform: uppercase;
   font-size: 1.4rem;
   font-weight: 400;
+  width: 100%;
 }
+
+@media (width > 767px) {
+  .filters-grid-container .action-button-wrapper .action-button {
+    padding: 1.9rem 0 1.4rem 0;
+    min-width: 17rem;
+    width: unset;
+  }
+}
+
+.mob-secondary-view,
+.mob-secondary-view .row {
+  display: none;
+  flex-direction: column;
+}
+
+@media (width > 767px) {
+  .mob-secondary-view,
+  .mob-secondary-view .row {
+    display: none;
+  }
+}
+
+.mob-secondary-view .row.show {
+  display: block;
+}
+
+.mob-secondary-view .icon.rotate-left {
+  transform: rotate(180deg);
+  display: inline-block;
+}
+
+.mob-secondary-view .icon::before {
+  font-size: 1.2rem;
+}
+
+.mob-secondary-view .heading-wrapper {
+  display: flex;
+  gap: 3rem;
+  margin-bottom: 5rem;
+}
+
+.mob-secondary-view .heading-wrapper h5 {
+  font-family: tungstenw05-medium, Oswald, sans-serif;
+  color: var(--dark-slate-gray);
+  line-height: 1;
+  font-weight: 500;
+  font-size: 3.6rem;
+  margin-block: auto;
+}
+
+.mob-secondary-view .row ul {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  height: fit-content;
+}
+
+.mob-secondary-view .row ul li {
+  position: relative;
+  border: 1px solid white;
+  border-radius: 25px;
+  width: fit-content;
+  white-space: nowrap;
+  padding: 0.6rem 1.5rem 0.7rem;
+  font-size: 1.4rem;
+}
+
+.mob-secondary-view .filter-input {
+  position: absolute;
+  opacity: 0;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  margin-top: -0.2rem;
+  cursor: pointer;
+}
+
+.mob-secondary-view .filters-list li:has(input:checked) {
+  background-color: var(--black-olive);
+  color: white;
+}
+
+.mob-secondary-view .filters-list li:has(input:not(:checked)) {
+  background-color: #00b28f;
+  color: white;
+}
+
+.mob-secondary-view .continue-button {
+  background-color: white;
+  color: var(--black-olive);
+  padding: 1rem;
+  margin-block: 5rem;
+  text-decoration: none;
+  text-align: center;
+  text-transform: uppercase;
+  font-size: 1.2rem;
+}
+
+.mob-secondary-view .continue-button:hover {
+  background-color: var(--black-olive);
+  color: white;
+}
+
+
 

--- a/blocks/filters-grid/filters-grid.css
+++ b/blocks/filters-grid/filters-grid.css
@@ -2,7 +2,7 @@ main .modal dialog[data-link="/modals/explore"] {
   width: 100%;
   max-width: 100%;
   margin-top: 25%;
-  padding: 1rem 0 0 0;
+  padding: 1rem 0 0;
   border-radius: 0.3rem 0.3rem 0 0;
   background-color: var(--spring-green);
   color: white;
@@ -80,7 +80,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   align-items: center;
 }
 
-.filters-grid .row .row-heading-wrapper .icon {
+.section .filters-grid .row .row-heading-wrapper .icon {
   cursor: pointer;
   font-size: 1.2rem;
 }
@@ -121,6 +121,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
 }
 
 .filters-grid .row ul li {
+  position: relative;
   border: 1px solid var(--silver);
   border-radius: 25px;
   width: fit-content;
@@ -137,10 +138,6 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   }
 }
 
-.filters-grid .filters-list li {
-  position: relative;
-}
-
 .filters-grid .filter-input {
   position: absolute;
   opacity: 0;
@@ -151,24 +148,24 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   margin-top: -0.2rem;
 }
 
-.filters-grid .row ul.filters-list li:hover {
+.filters-grid ul li:has(input:checked) {
   background-color: var(--black-olive);
   color: white;
 }
 
-.filters-grid .filters-list li:has(input:checked) {
-  background-color: var(--black-olive);
-  color: white;
-}
-
-.filters-grid .filters-list li:has(input:not(:checked)) {
+.filters-grid ul li:has(input:not(:checked)) {
   background-color: white;
   color: var(--bright-blue);
 }
 
+.filters-grid ul.filters-list li:hover {
+  background-color: var(--black-olive);
+  color: white;
+}
+
 /* heading */
 .filters-grid-container h3 {
-  font-family: tungstenw05-medium, Oswald, sans-serif;
+  font-family: var(--heading-font-family);
   color: white;
   line-height: 1.5;
   font-weight: 900;
@@ -193,7 +190,6 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
 }
 
 .filters-grid h5 {
-  padding-bottom: 0.8rem;
   font-family: inherit;
   font-size: 1.4rem;
   font-weight: 600;
@@ -216,6 +212,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
     letter-spacing: 1px;
     text-transform: uppercase;
   }
+
   .filters-grid .row-heading-wrapper::after {
     display: none;
   }
@@ -280,7 +277,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
 
 @media (width > 767px) {
   .filters-grid-container .action-button-wrapper .action-button {
-    padding: 1.9rem 0 1.4rem 0;
+    padding: 1.9rem 0 1.4rem;
     min-width: 17rem;
     width: unset;
   }
@@ -309,7 +306,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   cursor: pointer;
 }
 
-.mob-secondary-view .icon::before {
+.mob-secondary-view .icon.rotate-left::before {
   font-size: 1.2rem;
 }
 
@@ -320,7 +317,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
 }
 
 .mob-secondary-view .heading-wrapper h5 {
-  font-family: tungstenw05-medium, Oswald, sans-serif;
+  font-family: var(--heading-font-family);
   color: var(--dark-slate-gray);
   line-height: 1;
   font-weight: 500;
@@ -337,7 +334,7 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   height: fit-content;
 }
 
-.mob-secondary-view .row ul li {
+.section .mob-secondary-view .row ul li {
   position: relative;
   border: 1px solid white;
   border-radius: 25px;
@@ -383,6 +380,3 @@ main .modal dialog[data-link="/modals/explore"] .close-button .icon::before {
   background-color: var(--black-olive);
   color: white;
 }
-
-
-

--- a/blocks/filters-grid/filters-grid.css
+++ b/blocks/filters-grid/filters-grid.css
@@ -1,0 +1,126 @@
+main .modal dialog[data-link="/modals/explore"] {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  min-height: fit-content;
+  padding: 2rem;
+  margin-block: 2rem;
+  border-radius: 0;
+}
+
+@media (width > 1210px) {
+  main .modal dialog[data-link="/modals/explore"] {
+    max-width: 1170px;
+    padding-inline: 0;
+    margin-inline: auto;
+  }
+}
+
+main .modal dialog[data-link="/modals/explore"] .close-button {
+  margin-top: 5rem;
+  margin-right: 1rem;
+  color: var(--dark-gunmetal);
+}
+
+.filters-grid .row ul {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+  gap: 1rem;
+  height: 105px;
+  overflow: hidden;
+}
+
+.filters-grid .row ul.expanded {
+  height: fit-content;
+}
+
+.filters-grid .row ul li {
+  border: 1px solid var(--silver);
+  border-radius: 25px;
+  width: fit-content;
+  white-space: nowrap;
+  padding: 0.6rem 1.5rem 0.7rem;
+  color: var(--bright-blue);
+}
+
+.filters-grid .filters-list li {
+  position: relative;
+}
+
+.filters-grid .filter-input {
+  position: absolute;
+  opacity: 0;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  margin-top: -0.2rem;
+}
+
+.filters-grid .row ul.filters-list li:hover {
+  background-color: var(--black-olive);
+  color: white;
+}
+
+.filters-grid .filters-list li:has(input:checked) {
+  background-color: var(--black-olive);
+  color: white;
+}
+
+.filters-grid .filters-list li:has(input:not(:checked)) {
+  background-color: white;
+  color: var(--bright-blue);
+}
+
+.filters-grid-container h3 {
+  font-family: inherit;
+  color: var(--dark-slate-gray);
+  line-height: 1.5;
+  font-weight: 900;
+  font-size: 3.6rem;
+  margin-bottom: 7rem;
+}
+
+.filters-grid h5 {
+  letter-spacing: 1px;
+  padding-bottom: 0.8rem;
+  text-transform: uppercase;
+  font-family: inherit;
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.filters-grid .view-all {
+  text-decoration: none;
+  color: black;
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.filters-grid-container .action-button-wrapper {
+  margin-top: 3.5rem;
+}
+
+.filters-grid-container .action-button-wrapper::before {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 1px;
+  background: var(--silver);
+}
+
+.filters-grid-container .action-button-wrapper .action-button {
+  border-radius: 0;
+  background-color: var(--black-olive);
+  color: white;
+  padding: 1.9rem 0 1.4rem 0;
+  min-width: 17rem;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  font-size: 1.4rem;
+  font-weight: 400;
+}
+

--- a/blocks/filters-grid/filters-grid.js
+++ b/blocks/filters-grid/filters-grid.js
@@ -6,6 +6,60 @@ const FILTER_CATEGORIES = {
   2: 'assetType',
 };
 
+// opens or closes the secondary view for mobile based on the 'openView' boolean value
+function handleSecondaryViewsForMobile(row, openView = true) {
+  const section = row.closest('.section');
+  const mobileSecondaryView = section.querySelector('.mob-secondary-view');
+  const primaryViewItems = section.querySelectorAll('.filters-grid-wrapper, .default-content-wrapper');
+
+  if (openView) {
+    const rect = section.getBoundingClientRect();
+    mobileSecondaryView.style.minHeight = `${rect.height}px`;
+    section.classList.add('expanded');
+    primaryViewItems.forEach((item) => {
+      item.style.display = 'none';
+    });
+
+    mobileSecondaryView.style.display = 'flex';
+    const mobRow = mobileSecondaryView.querySelector(`#${row.id}`);
+    mobRow.classList.add('show');
+  } else {
+    section.classList.remove('expanded');
+    row.classList.remove('show');
+    mobileSecondaryView.style.display = 'none';
+    primaryViewItems.forEach((item) => {
+      item.style.display = 'block';
+    });
+  }
+}
+
+function openSecondaryView(row) {
+  handleSecondaryViewsForMobile(row, true);
+}
+
+function closeSecondaryView(row) {
+  handleSecondaryViewsForMobile(row, false);
+}
+
+function getSelectedFiltersInRow(row) {
+  const checkedFilters = row.querySelectorAll('li:has(.filter-input:checked)');
+  if (!checkedFilters) return [];
+  return Array.from(checkedFilters).map((item) => item.querySelector('.filter-label').textContent);
+}
+
+function decorateRowHeading(row) {
+  const h5 = row.querySelector('h5');
+  if (h5) {
+    const headingParent = h5.parentElement;
+    const arrowControl = createAemElement('span', { class: 'icon icon-long-right-arrow' });
+    const headingWrapper = createAemElement('div', { class: 'row-heading-wrapper' }, null, h5, arrowControl);
+    const separator = createAemElement('div', { class: 'separator' });
+    headingParent.prepend(separator);
+    headingParent.prepend(headingWrapper);
+    arrowControl.addEventListener('click', () => openSecondaryView(row));
+  }
+}
+
 function decorateRowList(row) {
   const ul = row.querySelector('ul');
   if (ul) {
@@ -55,23 +109,91 @@ function decorateActionButton(block) {
     const rows = block.querySelectorAll('.row');
     rows.forEach((row, index) => {
       const category = FILTER_CATEGORIES[index];
-      const checkedFiltersItem = Array.from(row.querySelectorAll('li:has(.filter-input:checked)'))
-        .map((item) => item.querySelector('.filter-label').textContent);
-      selectedFilters[category] = checkedFiltersItem;
+      const checkedFiltersItem = getSelectedFiltersInRow(row);
+      if (checkedFiltersItem.length > 0) selectedFilters[category] = checkedFiltersItem;
     });
     const queryString = new URLSearchParams(selectedFilters).toString();
     actionButton.href = `${actionButton.href}?${queryString}`;
   });
 }
 
+function decorateSecondaryViewForMobile(block) {
+  const rows = block.querySelectorAll('.row');
+  const mobSecondaryView = createAemElement('div', { class: 'mob-secondary-view' });
+  rows.forEach((row, index) => {
+    const heading = row.querySelector('h5');
+    if (!heading) return;
+    const backArrow = createAemElement('span', { class: 'icon rotate-left icon-long-right-arrow' });
+    const clonedHeading = heading.cloneNode(true);
+    const headingWrapper = createAemElement('div', { class: 'heading-wrapper' }, null, backArrow, clonedHeading);
+    const clonedUl = row.querySelector('ul').cloneNode(true);
+    const mobRow = createAemElement('div', { class: 'row' }, { id: `row-${index}` }, headingWrapper, clonedUl);
+    mobSecondaryView.append(mobRow);
+    backArrow.addEventListener('click', () => closeSecondaryView(mobRow));
+  });
+
+  const continueButton = createAemElement('a', { class: 'continue-button' }, { textContent: 'Continue' });
+  mobSecondaryView.append(continueButton);
+  continueButton.addEventListener('click', (event) => {
+    event.stopPropagation();
+    const activeRow = mobSecondaryView.querySelector('.row.show');
+    const selectedFilters = getSelectedFiltersInRow(activeRow);
+    closeSecondaryView(activeRow);
+
+    const primaryRow = block.querySelector(`#${activeRow.id}`);
+    const filtersList = primaryRow.querySelector('ul');
+    const filters = filtersList.querySelectorAll('.filter-input');
+    filters.forEach((filter) => {
+      const label = filter.nextElementSibling;
+      if (selectedFilters.includes(label.textContent)) {
+        filter.checked = true;
+      } else {
+        filter.checked = false;
+      }
+    });
+  });
+
+  const section = block.closest('.section');
+  section.append(mobSecondaryView);
+}
+
+function decorateBlockByView(block) {
+  const mobileView = window.matchMedia('(max-width: 767px)');
+  if (!mobileView.matches) {
+    const section = block.closest('.section');
+    section.classList.remove('expanded');
+
+    const primaryViewItems = section.querySelectorAll('.filters-grid-wrapper, .default-content-wrapper');
+    primaryViewItems.forEach((item) => {
+      item.style.display = 'block';
+    });
+
+    const mobileSecondaryView = section.querySelector('.mob-secondary-view');
+    mobileSecondaryView.style.display = 'none';
+
+    const rows = block.querySelectorAll('.row');
+    rows.forEach((row) => {
+      row.style.display = 'block';
+    });
+  }
+}
+
+function handleWindowEvents(block) {
+  window.addEventListener('resize', () => {
+    decorateBlockByView(block);
+  }, true);
+}
+
 export default function decorate(block) {
   const rows = [...block.children];
-  rows.forEach((row) => {
+  rows.forEach((row, index) => {
+    row.id = `row-${index}`;
     row.classList.add('row');
+    decorateRowHeading(row);
     decorateRowList(row);
     decorateViewMore(row);
   });
   decorateActionButton(block);
-  const dialog = block.closest('dialog');
-  dialog.classList.add('full-width');
+  decorateSecondaryViewForMobile(block);
+  handleWindowEvents(block);
 }

--- a/blocks/filters-grid/filters-grid.js
+++ b/blocks/filters-grid/filters-grid.js
@@ -15,7 +15,6 @@ function handleSecondaryViewsForMobile(row, openView = true) {
   if (openView) {
     const rect = section.getBoundingClientRect();
     mobileSecondaryView.style.minHeight = `${rect.height}px`;
-    section.classList.add('expanded');
     primaryViewItems.forEach((item) => {
       item.style.display = 'none';
     });
@@ -24,7 +23,6 @@ function handleSecondaryViewsForMobile(row, openView = true) {
     const mobRow = mobileSecondaryView.querySelector(`#${row.id}`);
     mobRow.classList.add('show');
   } else {
-    section.classList.remove('expanded');
     row.classList.remove('show');
     mobileSecondaryView.style.display = 'none';
     primaryViewItems.forEach((item) => {
@@ -161,17 +159,13 @@ function decorateBlockByView(block) {
   const mobileView = window.matchMedia('(max-width: 767px)');
   if (!mobileView.matches) {
     const section = block.closest('.section');
-    section.classList.remove('expanded');
-
     const primaryViewItems = section.querySelectorAll('.filters-grid-wrapper, .default-content-wrapper');
+    const mobileSecondaryView = section.querySelector('.mob-secondary-view');
+    const rows = block.querySelectorAll('.row');
     primaryViewItems.forEach((item) => {
       item.style.display = 'block';
     });
-
-    const mobileSecondaryView = section.querySelector('.mob-secondary-view');
     mobileSecondaryView.style.display = 'none';
-
-    const rows = block.querySelectorAll('.row');
     rows.forEach((row) => {
       row.style.display = 'block';
     });

--- a/blocks/filters-grid/filters-grid.js
+++ b/blocks/filters-grid/filters-grid.js
@@ -1,0 +1,77 @@
+import { createAemElement } from '../../scripts/blocks-utils.js';
+
+const FILTER_CATEGORIES = {
+  0: 'industry',
+  1: 'technology',
+  2: 'assetType',
+};
+
+function decorateRowList(row) {
+  const ul = row.querySelector('ul');
+  if (ul) {
+    ul.classList.add('filters-list');
+    const li = [...ul.children];
+    li.forEach((item) => {
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.classList.add('filter-input');
+
+      const label = document.createElement('label');
+      label.classList.add('filter-label');
+      label.textContent = item.textContent;
+      item.textContent = '';
+
+      item.prepend(checkbox);
+      item.appendChild(label);
+    });
+  }
+}
+
+function decorateViewMore(row) {
+  const viewMore = row.querySelector('p');
+  const COLLAPSED_TEXT = 'View All';
+  const EXPANDED_TEXT = 'View Less';
+  if (viewMore && viewMore.textContent.trim() === COLLAPSED_TEXT) {
+    const viewMoreLink = createAemElement('a', { class: 'view-all' }, { textContent: COLLAPSED_TEXT });
+    viewMore.after(viewMoreLink);
+    viewMore.remove();
+    viewMoreLink.onclick = (event) => {
+      event.preventDefault();
+      const filtersList = row.querySelector('ul');
+      viewMoreLink.textContent = filtersList.classList.contains('expanded') ? COLLAPSED_TEXT : EXPANDED_TEXT;
+      filtersList.classList.toggle('expanded');
+    };
+  }
+}
+
+function decorateActionButton(block) {
+  const section = block.closest('.section');
+  const actionButton = section.querySelector('.filters-grid-wrapper + .default-content-wrapper p >  a');
+  if (actionButton === null) return;
+  actionButton.classList.add('action-button');
+  actionButton.parentElement.classList.add('action-button-wrapper');
+  actionButton.addEventListener('click', () => {
+    const selectedFilters = {};
+    const rows = block.querySelectorAll('.row');
+    rows.forEach((row, index) => {
+      const category = FILTER_CATEGORIES[index];
+      const checkedFiltersItem = Array.from(row.querySelectorAll('li:has(.filter-input:checked)'))
+        .map((item) => item.querySelector('.filter-label').textContent);
+      selectedFilters[category] = checkedFiltersItem;
+    });
+    const queryString = new URLSearchParams(selectedFilters).toString();
+    actionButton.href = `${actionButton.href}?${queryString}`;
+  });
+}
+
+export default function decorate(block) {
+  const rows = [...block.children];
+  rows.forEach((row) => {
+    row.classList.add('row');
+    decorateRowList(row);
+    decorateViewMore(row);
+  });
+  decorateActionButton(block);
+  const dialog = block.closest('dialog');
+  dialog.classList.add('full-width');
+}

--- a/blocks/hero-slider/hero-slider.css
+++ b/blocks/hero-slider/hero-slider.css
@@ -80,7 +80,6 @@ div.section.hero-slider-container {
   font-size: var(--banner-title-font-size);
   font-weight: 300;
   line-height: 7.5rem;
-  /*margin-top: 2rem;*/
 }
 
 .hero-slider .banner-content a.report-button {

--- a/blocks/hero-slider/hero-slider.css
+++ b/blocks/hero-slider/hero-slider.css
@@ -10,7 +10,7 @@ div.section.hero-slider-container {
   --banner-title-font-color: white;
   --banner-title-font-family: var(--heading-font-family);
   --banner-title-font-size: var(--heading-font-size-xxl);
-  --banner-content-top: 38%;
+  --banner-content-top: 48%;
   --card-bg-color: white;
   --card-item-font-size: 1.6rem;
   --card-item-find-more-font-size: 1.8rem;
@@ -25,6 +25,12 @@ div.section.hero-slider-container {
   --arrow-control-top: 116%;
 }
 
+@media (width > 767px) {
+  .hero-slider {
+   --banner-content-top: 38%;
+  }
+}
+
 @media (width > 990px) {
   div.section.hero-slider-container {
     margin-bottom: 10rem;
@@ -33,7 +39,7 @@ div.section.hero-slider-container {
   .hero-slider {
     --card-item-font-size: 1.8rem;
     --card-item-find-more-font-size: 2rem;
-    --banner-content-top: 28%;
+    --banner-content-top: 26%;
   }
 }
 
@@ -58,6 +64,9 @@ div.section.hero-slider-container {
 
 .hero-slider .banner-content {
   position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
   top: var(--banner-content-top);
 }
 
@@ -71,7 +80,7 @@ div.section.hero-slider-container {
   font-size: var(--banner-title-font-size);
   font-weight: 300;
   line-height: 7.5rem;
-  margin-top: 2rem;
+  /*margin-top: 2rem;*/
 }
 
 .hero-slider .banner-content a.report-button {
@@ -84,6 +93,7 @@ div.section.hero-slider-container {
   padding: 7px 18px 5px;
   letter-spacing: 0.16rem;
   text-align: center;
+  width: fit-content;
 }
 
 .hero-slider .cards-list {
@@ -95,6 +105,7 @@ div.section.hero-slider-container {
   width: 100%;
   bottom: -11%;
   height: 164px;
+  margin-top: 2rem;
 }
 
 .hero-slider .card-item {

--- a/blocks/modal/modal.js
+++ b/blocks/modal/modal.js
@@ -47,7 +47,7 @@ export async function createModal(contentNodes, id) {
     closeButton.classList.add('close-button');
     closeButton.setAttribute('aria-label', 'Close');
     closeButton.type = 'button';
-    closeButton.innerHTML = '<span class="icon icon-bx-x"></span>';
+    closeButton.innerHTML = '<span class="icon icon-popup-cross"></span>';
     closeButton.addEventListener('click', () => dialog.close());
     dialog.append(closeButton);
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -31,6 +31,31 @@ function buildHeroBlock(main) {
 }
 
 /**
+ * The function checks if the first H2 heading of each section is immediately followed by a button.
+ * If such a pattern is found, it wraps both the H2 heading and the button in a div
+ * with the classes 'advanced-heading' and 'heading-button'.
+ *
+ * Note: This function currently only targets H2 headings.
+ * However, it can be enhanced to also target and decorate H1 headings if required.
+ *
+ * @param {HTMLElement} main - The main element to decorate.
+ */
+function decorateSectionHeading(main) {
+  const sections = main.querySelectorAll('.section');
+  sections.forEach((section) => {
+    const sectionHeading = section.querySelector('h2:first-of-type');
+    const headingButton = sectionHeading ? sectionHeading.nextElementSibling : '';
+    if (headingButton && headingButton.classList.contains('button-container')) {
+      const headingParent = sectionHeading.parentElement;
+      const headingButtonWrapper = document.createElement('div');
+      headingButtonWrapper.classList.add('advanced-heading', 'heading-button');
+      headingButtonWrapper.append(sectionHeading, headingButton);
+      headingParent.append(headingButtonWrapper);
+    }
+  });
+}
+
+/**
  * load fonts.css and set a session storage flag
  */
 async function loadFonts() {
@@ -82,6 +107,7 @@ export function decorateMain(main) {
   decorateIcons(main);
   buildAutoBlocks(main);
   decorateSections(main);
+  decorateSectionHeading(main);
   decorateBlocks(main);
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -36,7 +36,7 @@ function buildHeroBlock(main) {
  * with the classes 'advanced-heading' and 'heading-button'.
  *
  * Note: This function currently only targets H2 headings.
- * However, it can be enhanced to also target and decorate H1 headings if required.
+ * However, it can be enhanced to decorate H1 and other headings if required.
  *
  * @param {HTMLElement} main - The main element to decorate.
  */

--- a/styles/icons.css
+++ b/styles/icons.css
@@ -26,15 +26,15 @@
 .icon-connect::before {
     content: "";
 }
-  
+
 .icon-request-expert::before {
     content: "";
 }
-  
+
 .icon-insights::before {
     content: "";
 }
-  
+
 .icon-podcasts::before {
     content: "";
 }
@@ -42,16 +42,16 @@
 .icon-apple::before {
     content: "";
 }
-  
+
 .icon-google::before {
     content: "";
 }
-  
+
 .icon-spotify::before {
     content: "";
     color: var(--light-green-color);
 }
-  
+
 .icon-sound-cloud::before {
     content: "";
 }
@@ -86,4 +86,5 @@
 
 .icon-popup-cross::before {
     content: "";
+    font-size: 1.5rem;
 }

--- a/styles/icons.css
+++ b/styles/icons.css
@@ -86,7 +86,6 @@
 
 .icon-popup-cross::before {
     content: "";
-    font-size: 1.5rem;
 }
 
 .icon-slick-arrow::before {
@@ -95,4 +94,12 @@
 
 .icon-right-angle::before {
     content: "";
+}
+
+.icon-long-right-arrow::before {
+  content: "";
+}
+
+.icon-long-left-arrow::before {
+  content: "";
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -44,6 +44,7 @@
   --dark-gunmetal: #212529;
   --navy-blue: #0c1220;
   --light-sky-blue: #d5eff9;
+  --dark-slate-gray: #3d4551;
 
   /* fonts */
   --body-font-family: myriad-pro, arial;
@@ -310,7 +311,7 @@ main .section > div > div.full-width, main .section > div:has(div.full-width) {
   }
 }
 
-main .section.top-heading-gray > div:first-child > h2:first-of-type {
+main .section.top-heading-gray h2:first-of-type {
   color: var(--black-olive);
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -49,6 +49,7 @@
   --orange: #f16c51;
   --grey-lighter: #707070;
   --dark-slate-gray: #3d4551;
+  --spring-green: #00b28f;
 
   /* fonts */
   --body-font-family: myriad-pro, arial;
@@ -344,7 +345,7 @@ main .scroll-to-top {
   }
 }
 
-@media (width > 1210px) {  
+@media (width > 1210px) {
   main .scroll-to-top {
     width: 7rem;
     height: 7rem;
@@ -353,7 +354,7 @@ main .scroll-to-top {
   main .scroll-to-top .icon-right-angle {
     font-size: 3rem;
   }
-  
+
   .section > div, .section > div > div {
     max-width: var(--content-width);
     margin: auto;


### PR DESCRIPTION
Implemented - 
1. **filters-grid** block for explore modal, that is ingested as a fragment while creating the modal. It is authored [here](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7B039DEC19-AF32-45CA-B928-AB9486096132%7D&file=explore.docx&action=default&mobileredirect=true).
2. **advanced-heading** block to add capability of adding button with H2 heading, it is auto-blocked. Author need to only add a link after first H2 in a section and it will be decorated using advanced-heading block css.

Fix #37 

Test URLs:
- Before: https://main--infosys--aemsites.hlx.live/drafts/anuj/iki
- After: https://explore--infosys--aemsites.hlx.live/drafts/anuj/iki
