### PR TITLE
Fixing section and block styling

### DIFF
--- a/blocks/advanced-heading/advanced-heading.css
+++ b/blocks/advanced-heading/advanced-heading.css
@@ -4,6 +4,10 @@
   align-items: center;
 }
 
+.advanced-heading.heading-button p {
+ all: unset;
+}
+
 .advanced-heading.heading-button a {
   position: relative;
   border-radius: 0;

--- a/blocks/hero-slider/hero-slider.css
+++ b/blocks/hero-slider/hero-slider.css
@@ -101,7 +101,7 @@ div.section.hero-slider-container {
   flex-direction: row;
   cursor: pointer;
   box-shadow: 0 10px 20px rgb(0 0 0 / 19%), 0 6px 6px rgb(0 0 0 / 23%);
-  width: 100%;
+  max-width: 100%;
   bottom: -11%;
   height: 164px;
   margin-top: 2rem;
@@ -224,6 +224,13 @@ div.section.hero-slider-container {
   .hero-slider .card-item.animate-l2r,
   .hero-slider .card-item.animate-r2l {
     animation: none;
+  }
+}
+
+@media (width > 1210px) {
+  .hero-slider .cards-list {
+    left: var(--padding-inline);
+    right: var(--padding-inline);
   }
 }
 

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -11,9 +11,6 @@
  */
 
 /* eslint-env browser */
-const BREAKPOINTS = {
-  large: window.matchMedia('(min-width: 1210px)'),
-};
 
 /**
  * log RUM if part of the sample.
@@ -527,8 +524,8 @@ function decorateSections(main) {
     if (sectionMeta) {
       const meta = readBlockConfig(sectionMeta);
       Object.keys(meta).forEach((key) => {
-        if (key === 'style' || (key === 'style-large' && BREAKPOINTS.large.matches)) {
-          const styles = meta[key]
+        if (key === 'style') {
+          const styles = meta.style
             .split(',')
             .filter((style) => style)
             .map((style) => toClassName(style.trim()));

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -48,7 +48,7 @@ function decorateSectionHeading(main) {
     if (headingButton && headingButton.classList.contains('button-container')) {
       const headingParent = sectionHeading.parentElement;
       const headingButtonWrapper = document.createElement('div');
-      headingButtonWrapper.classList.add('advanced-heading', 'heading-button');
+      headingButtonWrapper.classList.add('advanced-heading', 'heading-button', 'no-block-separator');
       headingButtonWrapper.append(sectionHeading, headingButton);
       headingParent.append(headingButtonWrapper);
     }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -99,6 +99,8 @@
 
   /* content width */
   --content-width: 1210px;
+
+  --padding-inline: 20px;
 }
 
 @font-face {
@@ -346,7 +348,6 @@ main .section h2:first-of-type {
   margin: 0;
 }
 
-/* sections */
 main .section.separator-top {
   padding-top: 64px;
 }
@@ -427,7 +428,7 @@ main .scroll-to-top {
   }
 
   main .section:not(.no-inline-padding) > div > div.full-width-background {
-    padding-inline: 20px;
+    padding-inline: var(--padding-inline);
   }
 }
 
@@ -435,7 +436,6 @@ main .section.top-heading-gray h2:first-of-type {
   color: var(--black-olive);
 }
 
-/* section metadata */
 main .section.light,
 main .section.highlight {
   background-color: var(--light-color);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -353,11 +353,11 @@ main .section.separator-top {
 }
 
 main .section.separator-bottom {
-  padding-bottom: 64px;
+  padding-bottom: 128px;
 }
 
 main .section .block:not(.no-block-separator) {
-  padding-top: 32px;
+  padding-top: 48px;
 }
 
 main .section > div > div.full-width,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -415,8 +415,8 @@ main .scroll-to-top {
     font-size: 3rem;
   }
 
-  main .section > div,
-  main .section > div > div {
+  .section > div,
+  .section > div > div {
     max-width: var(--content-width);
     margin: auto;
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -99,7 +99,6 @@
 
   /* content width */
   --content-width: 1210px;
-
   --padding-inline: 20px;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -98,7 +98,7 @@
   --nav-height: 84px;
 
   /* content width */
-  --content-width: 1170px;
+  --content-width: 1210px;
 }
 
 @font-face {
@@ -108,21 +108,21 @@
   src: local('Arial');
 }
 
-@media (width >=376px) {
+@media (width >= 376px) {
   :root {
     --heading-font-size-xxl: calc(5.6 * var(--base-font-size));
     --heading-font-size-xl: calc(4.6 * var(--base-font-size));
   }
 }
 
-@media (width >=768px) {
+@media (width >= 768px) {
   :root {
     --heading-font-size-xxl: calc(8 * var(--base-font-size));
     --heading-font-size-xl: calc(7 * var(--base-font-size));
   }
 }
 
-@media (width >=992px) {
+@media (width >= 992px) {
   :root {
     --base-font-size: 9px;
     --heading-font-size-xxl: calc(8 * var(--base-font-size));
@@ -134,7 +134,7 @@
   }
 }
 
-@media (width >=1601px) {
+@media (width >= 1601px) {
   :root {
     --base-font-size: 10px;
     --heading-font-size-xxl: calc(8 * var(--base-font-size));
@@ -341,15 +341,22 @@ main .section.gray-background {
   background: var(--footer-links-bg-color);
 }
 
-main .section.no-margin,
-main .section.no-margin h1:first-of-type,
-main .section.no-margin h2:first-of-type {
+main .section h1:first-of-type,
+main .section h2:first-of-type {
   margin: 0;
 }
 
 /* sections */
-main .section:not(.no-top-padding) {
+main .section.separator-top {
   padding-top: 64px;
+}
+
+main .section.separator-bottom {
+  padding-bottom: 64px;
+}
+
+main .section .block:not(.no-block-separator) {
+  padding-top: 32px;
 }
 
 main .section > div > div.full-width,
@@ -365,7 +372,7 @@ main .scroll-to-top {
   display: none;
 }
 
-@media (width >=992px) {
+@media (width >= 992px) {
   main .scroll-to-top {
     position: fixed;
     right: 5%;
@@ -408,15 +415,19 @@ main .scroll-to-top {
     font-size: 3rem;
   }
 
-  .section > div,
-  .section > div > div {
+  main .section > div,
+  main .section > div > div {
     max-width: var(--content-width);
     margin: auto;
   }
 
-  .section > div:has(div.full-width-background) {
+  main .section > div:has(div.full-width-background) {
     max-width: 100%;
     margin: auto;
+  }
+
+  main .section:not(.no-inline-padding) > div > div.full-width-background {
+    padding-inline: 20px;
   }
 }
 


### PR DESCRIPTION
**Hero Slider Block**
<img width="634" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/98b1a2f8-7c06-43db-a436-d6326600e516">

<img width="609" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/95020d0a-78c7-43bb-b492-547f1853461a">

**Features Block**
<img width="554" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/32075a7e-070e-4cca-a7d4-98a2c9ec9585">

<img width="629" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/7303e428-d2fb-4bce-8c67-846f5a6ff7d9">

**Our Radar Block**

<img width="630" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/1d4089d4-c373-4141-a299-e88d1ff9049a">

**Most Popular Block**
<img width="616" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/6b857ba6-2503-4e5b-ae2e-8c1ceaa63277">

**Subscription Block**
<img width="560" alt="image" src="https://github.com/aemsites/infosys/assets/66720268/57e37388-2b3f-40d5-83ed-77dd5beb3c00">

Removed aem.js code handling inline padding specifically for large screen, which do not works on screens resize until page is reloaded, it is handled via css now.

Fix #57 

Test URLs:
- Before: https://main--infosys--aemsites.hlx.live/iki
- After: https://issue-57--infosys--aemsites.hlx.live/drafts/anuj/iki
