### PR TITLE
fix: accordion block & global styling issues

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -18,6 +18,7 @@
   padding: 0;
   min-height: 60rem;
   overflow: hidden;
+  margin: 0;
 }
 
 .accordion li {

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -55,13 +55,14 @@ function decorateContentLink(contentMainDiv) {
   }
 }
 
-function decorateContent(block, content) {
+function decorateContent(block, li, content) {
   if (!content) return;
   const children = [...content.children];
   const imageDiv = children[0];
   const contentMainDiv = children[1];
   content.classList.add('item-content', 'overlay');
   imageDiv.classList.add('item-content-image');
+  li.prepend(imageDiv);
   contentMainDiv.classList.add('item-content-main');
   const contentTitle = contentMainDiv.querySelector('h3');
   const titleDiv = content.previousElementSibling;
@@ -83,7 +84,7 @@ function createAccordionList(block) {
     const li = createAemElement('li', { class: 'item' });
     title.classList.add('item-title', 'overlay');
     const content = title.nextElementSibling;
-    decorateContent(block, content);
+    decorateContent(block, li, content);
     li.append(title, content);
     if (index === 0) {
       li.classList.add('active');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -112,14 +112,14 @@
 @media (width >= 376px) {
   :root {
     --heading-font-size-xxl: calc(5.6 * var(--base-font-size));
-    --heading-font-size-xl: calc(4.6 * var(--base-font-size));
+    --heading-font-size-xl: 4.14rem;
   }
 }
 
 @media (width >= 768px) {
   :root {
     --heading-font-size-xxl: calc(8 * var(--base-font-size));
-    --heading-font-size-xl: calc(7 * var(--base-font-size));
+    --heading-font-size-xl: 6.3rem;
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -125,7 +125,7 @@
 
 @media (width >= 992px) {
   :root {
-    --base-font-size: 9px;
+    --base-font-size: 8px;
     --heading-font-size-xxl: calc(8 * var(--base-font-size));
     --heading-font-size-xl: calc(7 * var(--base-font-size));
     --heading-font-size-l: calc(3 * var(--base-font-size));
@@ -347,17 +347,37 @@ main .section h2:first-of-type {
   margin: 0;
 }
 
-main .section.separator-top {
-  padding-top: 64px;
+main .section {
+  padding-block: 0;
 }
 
-main .section.separator-bottom {
-  padding-bottom: 128px;
+main .section.separator-top {
+  padding-top: 4.8rem;
 }
 
 main .section .block:not(.no-block-separator) {
-  padding-top: 48px;
+  padding-top: 1.6rem;
 }
+
+@media (width >= 768px) {
+  main .section.separator-top {
+    padding-top: 8.2rem;
+  }
+
+  main .section.separator-bottom-tablet-plus {
+    padding-bottom: 16.8rem;
+  }
+
+  main .section.gray-background-tablet-plus {
+    background: var(--footer-links-bg-color);
+  }
+
+  main .section .block:not(.no-block-separator) {
+    padding-top: 3.4rem;
+  }
+}
+
+
 
 main .section > div > div.full-width,
 main .section > div:has(div.full-width) {


### PR DESCRIPTION
- Accordion block DOM manipulation to not show white background during transition, matching the content image structure with original page to ensure similar effect.
- "Our Radar" Section vertical spacing matched with original page, in mobile view section bottom separator is removed, section separator top is different in mobile and tablet plus
- Global H2 font size base value matched with original page
- accordion list margin set to 0.
- Most Popular Section background gray color shows only for tablet and above

Fix #108 

Test URLs:
- Before: https://main--infosys--aemsites.hlx.live/drafts/anuj/iki
- After: https://issue-108--infosys--aemsites.hlx.live/anuj/iki
